### PR TITLE
Updated gradle dependencies, with version specific code changes in the Kotlin class

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,7 @@
       <configuration PROFILE_NAME="Debug" CONFIG_NAME="Debug" />
     </configurations>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,7 +35,7 @@ android {
         def kotlin_compiler_version = "1.4.30"
         kotlinCompilerVersion kotlin_compiler_version
 
-        def kotlin_compiler_extension_version = "1.0.0-beta01"
+        def kotlin_compiler_extension_version = compose_version
         kotlinCompilerExtensionVersion kotlin_compiler_extension_version
     }
     buildFeatures {
@@ -48,36 +48,35 @@ android {
 dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation 'androidx.core:core-ktx:1.6.0'
 
-    def app_compat = "1.2.0"
+    def app_compat = "1.3.1"
     implementation "androidx.appcompat:appcompat:$app_compat"
 
-    def material = "1.2.1"
+    def material = "1.4.0"
     implementation "com.google.android.material:material:$material"
 
-    def constraint_layout = "2.0.4"
+    def constraint_layout = "2.1.0"
     implementation "androidx.constraintlayout:constraintlayout:$constraint_layout"
 
     def androidx_ui = "1.0.0-alpha07"
     implementation "androidx.ui:ui-tooling:$androidx_ui"
 
-    def compose = "1.0.0-beta01"
-    implementation "androidx.compose.ui:ui:$compose"
-    implementation "androidx.compose.foundation:foundation:$compose"
-    implementation "androidx.compose.runtime:runtime-livedata:$compose"
-    implementation "androidx.compose.runtime:runtime-rxjava2:$compose"
-    implementation "androidx.compose.material:material:$compose"
-    implementation "androidx.compose.material:material-icons-core:$compose"
-    implementation "androidx.compose.material:material-icons-extended:$compose"
+    implementation "androidx.compose.ui:ui:$compose_version"
+    implementation "androidx.compose.foundation:foundation:$compose_version"
+    implementation "androidx.compose.runtime:runtime-livedata:$compose_version"
+    implementation "androidx.compose.runtime:runtime-rxjava2:$compose_version"
+    implementation "androidx.compose.material:material:$compose_version"
+    implementation "androidx.compose.material:material-icons-core:$compose_version"
+    implementation "androidx.compose.material:material-icons-extended:$compose_version"
 
-    def compose_constraint = "1.0.0-alpha03"
+    def compose_constraint = "1.0.0-beta02"
     implementation "androidx.constraintlayout:constraintlayout-compose:$compose_constraint"
 
-    def compose_activity = "1.3.0-alpha03"
+    def compose_activity = "1.3.1"
     implementation "androidx.activity:activity-compose:$compose_activity"
 
-    def nav_version = "2.3.2"
+    def nav_version = "2.3.5"
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 
@@ -85,11 +84,11 @@ dependencies {
     implementation "com.squareup.retrofit2:retrofit:$retrofit"
     implementation "com.squareup.retrofit2:converter-gson:$retrofit"
 
-    def hilt = "2.28-alpha"
+    def hilt = "2.37"
     implementation "com.google.dagger:hilt-android:$hilt"
     kapt "com.google.dagger:hilt-android-compiler:$hilt"
 
-    def hilt_lifecycle_viewmodel = "1.0.0-alpha01"
+    def hilt_lifecycle_viewmodel = "1.0.0-alpha03"
     implementation "androidx.hilt:hilt-lifecycle-viewmodel:$hilt_lifecycle_viewmodel"
     kapt "androidx.hilt:hilt-compiler:$hilt_lifecycle_viewmodel"
 

--- a/app/src/main/java/com/codingwithmitch/mvvmrecipeapp/di/AppModule.kt
+++ b/app/src/main/java/com/codingwithmitch/mvvmrecipeapp/di/AppModule.kt
@@ -5,12 +5,12 @@ import com.codingwithmitch.mvvmrecipeapp.presentation.BaseApplication
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ApplicationComponent
 import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
 @Module
-@InstallIn(ApplicationComponent::class)
+@InstallIn(SingletonComponent ::class)
 object AppModule {
 
     @Singleton

--- a/app/src/main/java/com/codingwithmitch/mvvmrecipeapp/di/NetworkModule.kt
+++ b/app/src/main/java/com/codingwithmitch/mvvmrecipeapp/di/NetworkModule.kt
@@ -6,14 +6,14 @@ import com.google.gson.GsonBuilder
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ApplicationComponent
+import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
-@InstallIn(ApplicationComponent::class)
+@InstallIn(SingletonComponent::class)
 object NetworkModule {
 
     @Singleton

--- a/app/src/main/java/com/codingwithmitch/mvvmrecipeapp/di/RepositoryModule.kt
+++ b/app/src/main/java/com/codingwithmitch/mvvmrecipeapp/di/RepositoryModule.kt
@@ -7,11 +7,11 @@ import com.codingwithmitch.mvvmrecipeapp.repository.RecipeRepository_Impl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ApplicationComponent
+import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
 @Module
-@InstallIn(ApplicationComponent::class)
+@InstallIn(SingletonComponent::class)
 object RepositoryModule {
 
     @Singleton

--- a/app/src/main/java/com/codingwithmitch/mvvmrecipeapp/presentation/ui/recipe/RecipeViewModel.kt
+++ b/app/src/main/java/com/codingwithmitch/mvvmrecipeapp/presentation/ui/recipe/RecipeViewModel.kt
@@ -3,8 +3,6 @@ package com.codingwithmitch.mvvmrecipeapp.presentation.ui.recipe
 import android.util.Log
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
-import androidx.hilt.Assisted
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -12,20 +10,23 @@ import com.codingwithmitch.mvvmrecipeapp.domain.model.Recipe
 import com.codingwithmitch.mvvmrecipeapp.presentation.ui.recipe.RecipeEvent.GetRecipeEvent
 import com.codingwithmitch.mvvmrecipeapp.repository.RecipeRepository
 import com.codingwithmitch.mvvmrecipeapp.util.TAG
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 import javax.inject.Named
 
 const val STATE_KEY_RECIPE = "recipe.state.recipe.key"
 
 @ExperimentalCoroutinesApi
+@HiltViewModel
 class RecipeViewModel
-@ViewModelInject
+@Inject
 constructor(
     private val recipeRepository: RecipeRepository,
-    private @Named("auth_token") val token: String,
-    @Assisted private val state: SavedStateHandle,
+    @Named("auth_token") private val token: String,
+    private val state: SavedStateHandle,
 ): ViewModel(){
 
     val recipe: MutableState<Recipe?> = mutableStateOf(null)

--- a/app/src/main/java/com/codingwithmitch/mvvmrecipeapp/presentation/ui/recipe_list/RecipeListViewModel.kt
+++ b/app/src/main/java/com/codingwithmitch/mvvmrecipeapp/presentation/ui/recipe_list/RecipeListViewModel.kt
@@ -3,8 +3,6 @@ package com.codingwithmitch.mvvmrecipeapp.presentation.ui.recipe_list
 import android.util.Log
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
-import androidx.hilt.Assisted
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -12,8 +10,10 @@ import com.codingwithmitch.mvvmrecipeapp.domain.model.Recipe
 import com.codingwithmitch.mvvmrecipeapp.presentation.ui.recipe_list.RecipeListEvent.*
 import com.codingwithmitch.mvvmrecipeapp.repository.RecipeRepository
 import com.codingwithmitch.mvvmrecipeapp.util.TAG
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 import javax.inject.Named
 
 const val PAGE_SIZE = 30
@@ -23,12 +23,13 @@ const val STATE_KEY_QUERY = "recipe.state.query.key"
 const val STATE_KEY_LIST_POSITION = "recipe.state.query.list_position"
 const val STATE_KEY_SELECTED_CATEGORY = "recipe.state.query.selected_category"
 
+@HiltViewModel
 class RecipeListViewModel
-@ViewModelInject
+@Inject
 constructor(
     private val repository: RecipeRepository,
-    private @Named("auth_token") val token: String,
-    @Assisted private val savedStateHandle: SavedStateHandle,
+    @Named("auth_token") private val token: String,
+    private val savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,18 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.4.30"
+    ext.kotlin_version = "1.5.21"
+    ext.compose_version = '1.0.2'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        def gradle = '7.0.0-alpha05'
+        def gradle = '7.0.2'
         classpath "com.android.tools.build:gradle:$gradle"
 
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
-        def hilt = "2.28-alpha"
+        def hilt = "2.38.1"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt"
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Feb 05 13:37:12 PST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
The current repository has some compatibility issues with **Android Studio Arctic Fox**. This issue won't allow the project to build and run. I've updated all dependencies to the latest stable version and made version-specific changes in the Kotlin classes. 

### Changes in Gradle:

- Updated build:gradle 7.0.0-alpha05 -> 7.0.2
- Updated compose 1.0.0-beta01 -> 1.0.2
- Updated hilt-android-gradle-plugin 2.28-alpha -> 2.38.1
- Updated core-ktx 1.3.2 -> 1.6.0
- Updated appcompat 1.2.0 -> 1.3.1
- Updated material 1.2.1 -> 1.4.0
- Updated constraintlayout 2.0.4 -> 2.1.0
- Updated constraintlayout-compose 1.0.0-alpha03 -> 1.0.0-beta02
- Updated activity-compose 1.3.0-alpha03 -> 1.3.1
- Updated navigation-fragment-ktx 2.3.2 -> 2.3.5
- Updated hilt-android 2.28-alpha -> 2.37
- Updated hilt-lifecycle-viewmodel 1.0.0-alpha01 -> 1.0.0-alpha03

### Changes in Kotlin Class:

**di**

- AppModile
- NetworkModule
- RepositoryModule

`ApplicationComponent` is Deprecated in Dagger Version **2.30** and removed in Dagger Version **2.31**. Alternatively, `SingletonComponent` should be used instead of `ApplicationComponent
`

**presentation -> ui -> recipe**
- RecipeViewModel
- RecipeListViewModel

In HILT **alpha03**, `@ViewModelInject` is deprecated and replaced by `@HiltViewModel`. We need to add the `@HiltViewModel` annotation at the **class** level, and the `@Inject` annotation at the **constructor**. Additionally, we don't need the `@Assisted` annotation anymore.