### PR TITLE
Update how we animate in compose

### DIFF
--- a/app/src/main/java/com/codingwithmitch/mvvmrecipeapp/presentation/components/PulsingDemo.kt
+++ b/app/src/main/java/com/codingwithmitch/mvvmrecipeapp/presentation/components/PulsingDemo.kt
@@ -1,7 +1,6 @@
 package com.codingwithmitch.mvvmrecipeapp.presentation.components
 
 import androidx.compose.animation.core.*
-import androidx.compose.animation.transition
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
@@ -9,79 +8,51 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.unit.dp
-import com.codingwithmitch.mvvmrecipeapp.presentation.components.PulseAnimationDefinitions.PulseState.FINAL
-import com.codingwithmitch.mvvmrecipeapp.presentation.components.PulseAnimationDefinitions.PulseState.INITIAL
-import com.codingwithmitch.mvvmrecipeapp.presentation.components.PulseAnimationDefinitions.pulseDefinition
-import com.codingwithmitch.mvvmrecipeapp.presentation.components.PulseAnimationDefinitions.pulsePropKey
-
 
 @Composable
-fun PulsingDemo(){
+fun PulsingDemo() {
     val color = MaterialTheme.colors.primary
 
-    val pulseAnim = transition(
-        definition = pulseDefinition,
-        initState = INITIAL,
-        toState = FINAL
+    val infiniteTransition = rememberInfiniteTransition()
+    val pulseMagnitude by infiniteTransition.animateFloat(
+        initialValue = 40f,
+        targetValue = 50f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(500, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Restart
+        )
     )
-
-    val pulseMagnitude = pulseAnim[pulsePropKey]
 
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .height(55.dp),
         horizontalArrangement = Arrangement.Center
-    ){
+    ) {
         Image(
             modifier = Modifier
                 .align(Alignment.CenterVertically)
                 .height(pulseMagnitude.dp)
-                .width(pulseMagnitude.dp)
-            ,
-            imageVector = Icons.Default.Favorite.copy(),
+                .width(pulseMagnitude.dp),
+            imageVector = Icons.Default.Favorite,
+            contentDescription = ""
         )
     }
 
-
     Canvas(
-        modifier = Modifier.fillMaxWidth().height(55.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(55.dp),
     ) {
         drawCircle(
             radius = pulseMagnitude,
             brush = SolidColor(color),
         )
-    }
-}
-
-
-object PulseAnimationDefinitions{
-
-    enum class PulseState{
-        INITIAL, FINAL
-    }
-
-    val pulsePropKey = FloatPropKey("pulseKey")
-
-    val pulseDefinition = transitionDefinition<PulseState> {
-        state(INITIAL) { this[pulsePropKey] = 40f }
-        state(FINAL) { this[pulsePropKey] = 50f }
-
-        transition(
-            INITIAL to FINAL,
-        ) {
-            pulsePropKey using infiniteRepeatable(
-                animation = tween(
-                    durationMillis = 500,
-                    easing = FastOutSlowInEasing
-                ),
-                repeatMode = RepeatMode.Restart
-            )
-        }
     }
 }
 


### PR DESCRIPTION
Closes #4 
Found that the older way of animating in compose doesn't work anymore, so updated the way how we animate in compose. Basically, using `rememberInfiniteTransition()`.
Reference: [Android official docs](https://developer.android.com/jetpack/compose/animation#rememberinfinitetransition)
Happy Hacktoberfest🤝✨